### PR TITLE
Redo modmenu parent

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -35,6 +35,8 @@
     "flamingo": "*"
   },
   "custom": {
-    "modmenu:parent": "carpet"
+    "modmenu": {
+      "parent": "carpet"
+    }
   }
 }


### PR DESCRIPTION
Stops log spam of `[main/WARN]: WARNING! Mod lunaar-carpet-addons is only using deprecated 'modmenu:parent' custom value! This will be removed in 1.18 snapshots, so ask the author of this mod to support the new API.`